### PR TITLE
Allow environment variable and maintain BC

### DIFF
--- a/jobs/facebook.rb
+++ b/jobs/facebook.rb
@@ -7,7 +7,7 @@ require 'json'
 # Config
 # ------
 # the fb id or username of the page you’re planning to track
-facebook_graph_username = 'foobugs'
+facebook_graph_username = ENV['FACEBOOK_GRAPH_USERNAME'] || 'foobugs'
 
 SCHEDULER.every '1m', :first_in => 0 do |job|
   http = Net::HTTP.new("graph.facebook.com")


### PR DESCRIPTION
In order to use this, you currently have to edit the code directly.
This change lets other devs drop it in, then set an ENV var to
override so the code doesn't have to change.
