### PR TITLE
Fix number of followers/following/tweets for twitter accounts having more than 1k users

### DIFF
--- a/jobs/twitter_user.rb
+++ b/jobs/twitter_user.rb
@@ -16,9 +16,9 @@ SCHEDULER.every '2m', :first_in => 0 do |job|
     puts "twitter communication error (status-code: #{response.code})\n#{response.body}"
   else
 
-    tweets = /profile["']>[\n\t\s]*<strong>([\d.]+)/.match(response.body)[1].delete('.').to_i
-    following = /following["']>[\n\t\s]*<strong>([\d.]+)/.match(response.body)[1].delete('.').to_i
-    followers = /followers["']>[\n\t\s]*<strong>([\d.]+)/.match(response.body)[1].delete('.').to_i
+    tweets = /profile["']>[\n\t\s]*<strong>([\d.,]+)/.match(response.body)[1].delete('.,').to_i
+    following = /following["']>[\n\t\s]*<strong>([\d.,]+)/.match(response.body)[1].delete('.,').to_i
+    followers = /followers["']>[\n\t\s]*<strong>([\d.,]+)/.match(response.body)[1].delete('.,').to_i
     
     send_event('twitter_user_tweets', current: tweets)
     send_event('twitter_user_followers', current: followers)


### PR DESCRIPTION
For twitter accounts having more than 1k followers/following/tweets the current implementation do not strip the comma from the number (but the dot separator). However, some accounts (at least our :) ) have the "thousands separator" using comma. See https://www.diigo.com/item/image/42art/ae8j as an example.

The current PR should strip both dot and comma.
